### PR TITLE
Espresso - Mock location bug fix

### DIFF
--- a/locationsyncservice/src/main/java/com/shuttl/location_pings/mockLocation/MockLocationProvider.kt
+++ b/locationsyncservice/src/main/java/com/shuttl/location_pings/mockLocation/MockLocationProvider.kt
@@ -11,21 +11,23 @@ import android.os.SystemClock
 import android.util.Log
 import com.shuttl.location_pings.config.components.LocationConfigs
 
-class MockLocationProvider(applicationContext: Context) {
+class MockLocationProvider() {
 
     private val TAG: String? = "MockLocation"
     private var mockLocationProviderManager = MockLocationProviderManager()
-    private var configs: LocationConfigs = LocationConfigs()
 
     fun addMockLocationProvider(
         mLocationManager: LocationManager,
         context: Context,
-        locationListener: LocationListener
+        locationListener: LocationListener,
+        configs: LocationConfigs
+
     ) {
         addTestProviderToMockAvailableProviders(
             mLocationManager,
             LocationManager.GPS_PROVIDER,
-            locationListener
+            locationListener,
+            configs
         )
         setMockProviderLocationData(LocationManager.GPS_PROVIDER, context)
         Log.d(TAG, "addMockLocationProvider : Add provider and set mock location latLng")
@@ -35,7 +37,8 @@ class MockLocationProvider(applicationContext: Context) {
     private fun addTestProviderToMockAvailableProviders(
         mLocationManager: LocationManager,
         provider: String,
-        locationListener: LocationListener
+        locationListener: LocationListener,
+        configs:LocationConfigs
     ) {
         mLocationManager.addTestProvider(
             provider,
@@ -50,7 +53,7 @@ class MockLocationProvider(applicationContext: Context) {
             Criteria.ACCURACY_MEDIUM
         )
         mLocationManager.setTestProviderEnabled(provider, true)
-        subscribeMockLocationTracking(mLocationManager, provider, locationListener)
+        subscribeMockLocationTracking(mLocationManager, provider, locationListener, configs)
         Log.d(TAG, "addTestProviderToMockAvailableProviders : Add test provider = $provider"
         )
     }
@@ -59,13 +62,15 @@ class MockLocationProvider(applicationContext: Context) {
     private fun subscribeMockLocationTracking(
         mLocationManager: LocationManager,
         provider: String,
-        locationListener: LocationListener
+        locationListener: LocationListener,
+        configs: LocationConfigs
+
     ) {
         mLocationManager.requestLocationUpdates(provider, configs.minTimeInterval.toLong(), configs.minDistanceInterval.toFloat(), locationListener)
         Log.d(TAG, "subscribeMockLocationTracking : Request for location updates")
     }
 
-    private fun setMockProviderLocationData(provider: String, context: Context) {
+    public fun setMockProviderLocationData(provider: String, context: Context) {
         val location = Location(provider)
         location.latitude = mockLocationProviderManager.getMockLocationProviderLatitude(context).toDouble()
         location.longitude = mockLocationProviderManager.getMockLocationProviderLongitude(context).toDouble()

--- a/locationsyncservice/src/main/java/com/shuttl/location_pings/service/MockLocationSaveService.kt
+++ b/locationsyncservice/src/main/java/com/shuttl/location_pings/service/MockLocationSaveService.kt
@@ -58,10 +58,12 @@ class MockLocationSaveService : Service() {
     override fun onCreate() {
         startForeground(1, notification(this, "Updating mock location details..."))
         Log.d(TAG, "onCreate : Start foreground service to sync mock location")
-        work()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        var bundle :Bundle ?= intent?.extras
+        configs = bundle!!.getParcelable("config")!!
+        work()
         return START_STICKY
     }
 
@@ -73,7 +75,7 @@ class MockLocationSaveService : Service() {
             mockLocationListener,
             configs
         )
-        Log.d(TAG, "work : Start mock location provider ")
+        Log.d(TAG, "work : Start mock location provider with config : minTimeInterval= " + configs.minTimeInterval.toLong() + " minDistanceInterval = " + configs.minDistanceInterval.toFloat())
     }
 
     fun saveMockLocationInDB(location: Location?) {


### PR DESCRIPTION
**Modified files :**
    - **MockLocationProvider**
    - **MockLocationSaveService**

- **Bug-1**: Not getting multiple locations update from sharedPreference 
**Solution** : Call setMockProviderLocationData() inside onLocationChange() 

- **Bug-2**: Not receiving custom config data for **requestLocationUpdates**
**Solution** : Get config inside onStartCommand(), Pass LocationConfigs as param in **MockLocationProvider** class